### PR TITLE
[#19][🐛Bug] 총직원수, 부서/직무별 직원수 count 로직 수정

### DIFF
--- a/src/main/java/com/codeit/demo/controller/EmployeeController.java
+++ b/src/main/java/com/codeit/demo/controller/EmployeeController.java
@@ -135,6 +135,6 @@ public class EmployeeController implements EmployeeApi {
   @GetMapping("/stats/distribution")
   public ResponseEntity<List<EmployeeDistributionDto>> getEmployeeDistribution(
       @RequestParam(defaultValue = "department") String groupBy) {
-    return ResponseEntity.ok(employeeService.getEmployeeDistribution(groupBy));
+    return ResponseEntity.ok(employeeService.findEmployeeDistribution(groupBy));
   }
 }

--- a/src/main/java/com/codeit/demo/repository/EmployeeStatsRepository.java
+++ b/src/main/java/com/codeit/demo/repository/EmployeeStatsRepository.java
@@ -22,7 +22,7 @@ import static com.codeit.demo.entity.QEmployee.employee;
 @Repository
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class TrendRepository {
+public class EmployeeStatsRepository {
     private final JPAQueryFactory query;
 
     public int findEmployeeCountByDate(LocalDate date) {

--- a/src/main/java/com/codeit/demo/repository/TrendRepository.java
+++ b/src/main/java/com/codeit/demo/repository/TrendRepository.java
@@ -29,16 +29,6 @@ public class TrendRepository {
         return result != null ? result.intValue() : 0;
     }
 
-    public int findNewHires(LocalDate start, LocalDate end) {
-        Long result = query
-                .select(employee.count())
-                .from(employee)
-                .where(employee.hireDate.between(start, end))
-                .fetchOne();
-        return result != null ? result.intValue() : 0;
-
-    }
-
     public int findResigned(LocalDate start, LocalDate end) {
         Instant startInstant = start.atStartOfDay(ZoneId.systemDefault()).toInstant();
         Instant endInstant = end.atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant();
@@ -67,6 +57,35 @@ public class TrendRepository {
                         .and(changeDescription.before.eq("RESIGNED"))
                         .and(changeDescription.after.in("ACTIVE", "ON_LEAVE"))
                         .and(changeDescription.changeLog.at.goe(startInstant))
+                        .and(changeDescription.changeLog.at.loe(endInstant)))
+                .fetchOne();
+
+        return result != null ? result.intValue() : 0;
+    }
+
+    public int findTotalResigned(LocalDate end) {
+        Instant endInstant = end.atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant();
+
+        Long result = query
+                .select(changeDescription.count())
+                .from(changeDescription)
+                .where(changeDescription.propertyName.eq(PropertyName.STATUS)
+                        .and(changeDescription.after.eq("RESIGNED"))
+                        .and(changeDescription.changeLog.at.loe(endInstant)))
+                .fetchOne();
+
+        return result != null ? result.intValue() : 0;
+    }
+
+    public int findTotalReturned(LocalDate end) {
+        Instant endInstant = end.atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant();
+
+        Long result = query
+                .select(changeDescription.count())
+                .from(changeDescription)
+                .where(changeDescription.propertyName.eq(PropertyName.STATUS)
+                        .and(changeDescription.before.eq("RESIGNED"))
+                        .and(changeDescription.after.in("ACTIVE", "ON_LEAVE"))
                         .and(changeDescription.changeLog.at.loe(endInstant)))
                 .fetchOne();
 

--- a/src/main/java/com/codeit/demo/repository/TrendRepository.java
+++ b/src/main/java/com/codeit/demo/repository/TrendRepository.java
@@ -24,7 +24,7 @@ public class TrendRepository {
         Long result = query
                 .select(employee.count())
                 .from(employee)
-                .where(employee.hireDate.loe(date).and(employee.status.ne(EmploymentStatus.RESIGNED)))
+                .where(employee.hireDate.loe(date))
                 .fetchOne();
         return result != null ? result.intValue() : 0;
     }
@@ -55,5 +55,23 @@ public class TrendRepository {
 
         return result != null ? result.intValue() : 0;
     }
+
+    public int findReturned(LocalDate start, LocalDate end) {
+        Instant startInstant = start.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        Instant endInstant = end.atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant();
+
+        Long result = query
+                .select(changeDescription.count())
+                .from(changeDescription)
+                .where(changeDescription.propertyName.eq(PropertyName.STATUS)
+                        .and(changeDescription.before.eq("RESIGNED"))
+                        .and(changeDescription.after.in("ACTIVE", "ON_LEAVE"))
+                        .and(changeDescription.changeLog.at.goe(startInstant))
+                        .and(changeDescription.changeLog.at.loe(endInstant)))
+                .fetchOne();
+
+        return result != null ? result.intValue() : 0;
+    }
+
 }
 

--- a/src/main/java/com/codeit/demo/service/EmployeeService.java
+++ b/src/main/java/com/codeit/demo/service/EmployeeService.java
@@ -63,6 +63,6 @@ public interface EmployeeService {
   List<EmployeeTrendDto> findTrends(LocalDate from, LocalDate to, String unit);
 
   // 직원 분포 통계 조회
-  List<EmployeeDistributionDto> getEmployeeDistribution(String groupBy);
+  List<EmployeeDistributionDto> findEmployeeDistribution(String groupBy);
 
 }

--- a/src/main/java/com/codeit/demo/service/impl/EmployeeServiceImpl.java
+++ b/src/main/java/com/codeit/demo/service/impl/EmployeeServiceImpl.java
@@ -9,7 +9,7 @@ import com.codeit.demo.dto.request.EmployeeUpdateRequest;
 import com.codeit.demo.entity.BinaryContent;
 import com.codeit.demo.entity.Department;
 import com.codeit.demo.entity.Employee;
-import com.codeit.demo.repository.TrendRepository;
+import com.codeit.demo.repository.EmployeeStatsRepository;
 import com.codeit.demo.service.ChangeLogService;
 import com.codeit.demo.entity.enums.EmploymentStatus;
 import com.codeit.demo.exception.DepartmentNotFoundException;
@@ -22,11 +22,8 @@ import com.codeit.demo.service.BinaryContentService;
 import com.codeit.demo.service.EmployeeService;
 import jakarta.persistence.EntityNotFoundException;
 import java.io.IOException;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,12 +32,9 @@ import java.util.stream.IntStream;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cglib.core.Local;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -55,7 +49,7 @@ public class EmployeeServiceImpl implements EmployeeService {
   private final EmployeeMapper employeeMapper;
   private final BinaryContentService binaryContentService;
   private final ChangeLogService changeLogService;
-  private final TrendRepository trendRepository;
+  private final EmployeeStatsRepository trendRepository;
 
 
   @Override

--- a/src/main/java/com/codeit/demo/service/impl/EmployeeServiceImpl.java
+++ b/src/main/java/com/codeit/demo/service/impl/EmployeeServiceImpl.java
@@ -332,11 +332,10 @@ public class EmployeeServiceImpl implements EmployeeService {
   @Override
   @Transactional(readOnly = true)
   public long countEmployees(String status, LocalDate fromDate, LocalDate toDate) {
-    int count = 0;
-    if (fromDate==null||toDate == null) {
-      count = trendRepository.findEmployeeCountByDate(toDate);
+    if (toDate == null) {
+      toDate = LocalDate.now();
     }
-      return count;
+    return trendRepository.findEmployeeCountByDate(toDate)-trendRepository.findTotalResigned(toDate)+trendRepository.findTotalReturned(toDate);
   }
 
   @Override


### PR DESCRIPTION
## 버그 해결 후 화면


https://github.com/user-attachments/assets/45404ef8-40fd-4d2a-a5cf-6e31b12cf2b1

총 직원수, 부서/직무별 count 결과 화면입니다.

## 버그 설명
<img width="840" alt="스크린샷 2025-03-21 오전 10 52 40" src="https://github.com/user-attachments/assets/890aa3ba-ecc4-41e7-85c9-ee4519e5569f" />

중간에 퇴사 상태로 바꾸거나 퇴사상태를 재직 혹은 휴직중으로 바꿨을 때 총직원수, 부서/직무별 직원수 count에 반영되지 않는 버그가 발견됐습니다. 이와 같은 문제가 발생한 이유는, 부서별/ 직함별 직원수를 구할 때 현재 날짜 기준 퇴사상태를 고려하지 않고 count를 했기 때문입니다.
 
## 해결 방법

<img width="1086" alt="스크린샷 2025-03-21 오전 10 59 59" src="https://github.com/user-attachments/assets/57bbc074-03aa-4723-a58c-f407a8001f64" />

퇴사상태가 아니며 오늘날짜 기준으로 부서/직함별 직원수를 count 하였습니다. 

## 추가코멘트
TrendRepository를 EmployeeStatsRepository로 이름을 변경하였습니다.
Querydsl 사용에 익숙해지기 위해 기존 코드에서 Querydsl로 변경해보았습니다.

## 이슈트래거
Ref : #19 
