### PR TITLE
Fix: ChangeLog 예외 처리 강화

### DIFF
--- a/src/main/java/com/codeit/demo/service/impl/ChangeLogServiceImpl.java
+++ b/src/main/java/com/codeit/demo/service/impl/ChangeLogServiceImpl.java
@@ -15,6 +15,7 @@ import com.codeit.demo.service.ChangeLogService;
 import com.codeit.demo.util.ClientInfo;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -141,7 +142,11 @@ public class ChangeLogServiceImpl implements ChangeLogService {
           break;
 
         default:
-          throw new IllegalArgumentException("Unsupported sort field: " + sortField);
+          cursorTime = getCursorTime(cursor);
+          page = changeLogCustomRepository.findAllWithCursorAt(employeeNumber, typeStr, ipAddress,
+              memo,
+              atFrom, atTo, idAfter, cursorTime, sortDirection, pageable);
+          break;
       }
     }
 
@@ -164,7 +169,11 @@ public class ChangeLogServiceImpl implements ChangeLogService {
 
   // 커서 시간을 `Instant`로 변환
   private Instant getCursorTime(Object cursor) {
-    return Instant.parse((String) cursor).atZone(ZoneId.of("Asia/Seoul")).toInstant();
+    try {
+      return Instant.parse((String) cursor).atZone(ZoneId.of("Asia/Seoul")).toInstant();
+    } catch (DateTimeParseException e) {
+      throw new IllegalArgumentException("잘못된 형식의 커서입니다.");
+    }
   }
 
   // `idAfter` 기반으로 IP 주소 조회


### PR DESCRIPTION
# 변경 내용
- 이슈 #24 스모킹 테스트에서 테스트한 예외 처리 모두 포함

- 수정 이력 건수 조회 API(/api/change-log/count)에서 검색 범위 시작일이 종료일보다 미래인 경우 예외 발생
- 목록 조회 시 잘못된 커서 형식을 보내는 경우 예외 발생
